### PR TITLE
fix: use delay mode and release power inhibitor on shutdown

### DIFF
--- a/src-tauri/src/core/power/inhibitor.rs
+++ b/src-tauri/src/core/power/inhibitor.rs
@@ -93,7 +93,7 @@ impl PowerInhibitorState {
                         match proxy
                             .call::<_, _, zbus::zvariant::OwnedFd>(
                                 "Inhibit",
-                                &("shutdown:sleep", "RClone Manager", reason, "block"),
+                                &("shutdown:sleep", "RClone Manager", reason, "delay"),
                             )
                             .await
                         {
@@ -119,6 +119,7 @@ impl PowerInhibitorState {
                                     }
                                 });
 
+                                let app_handle = _app.clone();
                                 tauri::async_runtime::spawn(async move {
                                     if let Ok(mut shutdown_stream) =
                                         proxy.receive_signal("PrepareForShutdown").await
@@ -127,8 +128,13 @@ impl PowerInhibitorState {
                                         while let Some(signal) = shutdown_stream.next().await {
                                             if let Ok(true) = signal.body().deserialize::<bool>() {
                                                 info!(
-                                                    "⚠️ OS Shutdown requested while power inhibitor is active"
+                                                    "⚠️ OS Shutdown requested while power inhibitor is active, releasing lock to allow shutdown"
                                                 );
+                                                if let Some(state) =
+                                                    app_handle.try_state::<PowerInhibitorState>()
+                                                {
+                                                    state.release().await;
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Problem
On Linux, while any mount/job is active, RClone Manager acquires a logind
inhibitor lock with MODE=block. This causes two issues:

1. `systemd-logind` **refuses** `ManagerReboot/Shutdown` entirely — on KDE Plasma,
   clicking "Restart" silently degrades into a black screen, waiting indefinitely instead of rebooting. 
   The reboot transaction never starts.
2. The `PrepareForShutdown=true` signal handler only logged a warning and never
   released the lock, so the lock survived until process exit even during shutdown.

## Fix
- Change the inhibitor mode from `"block"` to `"delay"`: logind proceeds with
  the reboot after its grace period instead of refusing it outright. A user app
  cannot truly block power-off anyway (power button, Ctrl+Alt+Del, remote admin).
- On `PrepareForShutdown=true`, actually call `state.release()` so the lock is
  released as soon as the OS begins shutting down — mirroring what already happens
  when all mounts are unmounted.

## Verification
Tested on CachyOS (systemd 261, Plasma 6): with kDrive mounted and the patched
binary running, `ListInhibitors` now shows mode "delay", and KDE Restart performs
a real reboot instead of logging out.